### PR TITLE
Fix: bug fixed session.py

### DIFF
--- a/src/season/data/sample/src/portal/season/model/auth/saml.py
+++ b/src/season/data/sample/src/portal/season/model/auth/saml.py
@@ -85,7 +85,8 @@ class SAML:
             userinfo = auth.get_attributes()
             sessiondata = dict()
             if SAML_ACS is not None:
-                sessiondata = season.util.fn.call(SAML_ACS, wiz=wiz, userinfo=userinfo)
+                compiler = season.util.compiler(SAML_ACS)
+                sessiondata = compiler.call(wiz=wiz, userinfo=userinfo)
             
             redirect = session.get('SAML_REDIRECT', None)
             try:

--- a/src/season/data/sample/src/portal/season/model/orm.py
+++ b/src/season/data/sample/src/portal/season/model/orm.py
@@ -206,7 +206,7 @@ class Model:
         db = self.orm
         if 'id' not in data and hasattr(db, "id"):
             cls = type(getattr(db, "id"))
-            if cls is not pw.IntegerField and cls is not pw.BigIntegerField:
+            if cls is not pw.IntegerField and cls is not pw.BigIntegerField and cls is not pw.AutoField:
                 obj_id = self.random(self.id_size)
                 if self.id_size == 32:
                     obj_id = str(int(time.time()*1000000)) + self.random(16)

--- a/src/season/data/sample/src/portal/season/model/session.py
+++ b/src/season/data/sample/src/portal/season/model/session.py
@@ -30,7 +30,7 @@ class Session:
     def user_id(self):
         config = wiz.model("portal/season/config")
         session_user_id = config.session_user_id
-        return session_user_id()
+        return session_user_id(wiz)
     
     def create(self, key):
         config = wiz.model("portal/season/config")

--- a/src/season/data/sample/src/portal/season/route/pwa.swjs/controller.py
+++ b/src/season/data/sample/src/portal/season/route/pwa.swjs/controller.py
@@ -1,4 +1,4 @@
 import os
-fs = wiz.workspace("service").fs(os.path.join("config", "pwa"))
+fs = wiz.project.fs(os.path.join("config", "pwa"))
 swjs = fs.read("sw.js", "")
 wiz.response.send(swjs, content_type="text/javascript; charset=utf-8")


### PR DESCRIPTION
- config/season.py로 키값을 다른걸 쓰려고 wiz.session.get("key")를 하면 wiz를 못찾아서 에러가 납니다.
- 버전 업데이트 하면서 반영이 안된 saml.py 수정했습니다.
- orm.py에 insert 시 id값 관련 조건 하나 추가했습니다.
- 버전 업데이트 하면서 반영이 안된 swjs route 수정했습니다.